### PR TITLE
Add navigation system

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,12 @@ i18n.setLocale(new Locale("fr")); // You can set the locale for future calls to 
 i18n.get("SAMPLE_KEY"); // Returns the French string for the given key
  
 ```
+
+## Navigation
+
+To navigate between views using a "traditional" URL state management, the project uses a navigation system which follows some rules:
+
+- All views which can be accessed through a URL must be defined in the `Route` enum (found in `src/main/java/demo/app/navigation/Route.java`. Each one of them defines a `path` (a URL path) and a `viewClass` (the view to be shown when navigating to the path)
+- The view with an empty `path` will be the default view
+- To navigate to other navigable views, use the `navigateTo()` method of the `Navigator` instance (found in `AppUI.getCurrentApp().getNavigator()`)
+- Views in the navigation system must extend `NavigableView`. To create non-navigable views, use `BaseView` (both found in `src/main/demo/lib/ui/`).

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,3 @@
 * [ ] DTO example
 * [ ] Docs system
-* [ ] Vaadin navigation system
+* [X] Vaadin navigation system

--- a/src/main/java/demo/app/navigation/Route.java
+++ b/src/main/java/demo/app/navigation/Route.java
@@ -1,0 +1,38 @@
+package demo.app.navigation;
+
+import demo.app.ui.home.HomeView;
+import demo.lib.navigator.NavigatorPath;
+import demo.lib.ui.NavigableView;
+
+public enum Route implements NavigatorPath {
+
+    // Instances
+    // ------------------------------------------------------------------------
+
+    // @formatter:off
+    HOME("", HomeView.class);
+    // @formatter:on
+
+    private final String path;
+    private final Class<? extends NavigableView> viewClass;
+
+    // Constructor
+    // ------------------------------------------------------------------------
+    private Route(String path, Class<? extends NavigableView> viewClass) {
+        this.path = path;
+        this.viewClass = viewClass;
+    }
+
+    // Public API
+    // ------------------------------------------------------------------------
+    @Override
+    public String getPath() {
+        return path;
+    }
+
+    @Override
+    public Class<? extends NavigableView> getViewClass() {
+        return viewClass;
+    }
+
+}

--- a/src/main/java/demo/app/ui/AppUI.java
+++ b/src/main/java/demo/app/ui/AppUI.java
@@ -1,13 +1,18 @@
 package demo.app.ui;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.vaadin.annotations.Theme;
-import com.vaadin.navigator.Navigator;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.spring.annotation.SpringUI;
 import com.vaadin.spring.navigator.SpringViewProvider;
 import com.vaadin.ui.UI;
+
+import demo.app.navigation.Route;
+import demo.lib.navigator.Navigator;
 
 @Theme("sample-theme")
 @SpringUI
@@ -22,14 +27,28 @@ public class AppUI extends UI {
     // ------------------------------------------------------------------------
     @Override
     protected void init(VaadinRequest vaadinRequest) {
-        Navigator navigator = new Navigator(this, this);
-        navigator.addProvider(viewProvider);
+        setupNavigator();
     }
 
     // Public API
     // ------------------------------------------------------------------------
+    /**
+     * Returns current application UI instance
+     *
+     * @return the application UI instance
+     */
     public static final AppUI getCurrentApp() {
         return (AppUI) UI.getCurrent();
+    }
+
+    // Private utils
+    // ------------------------------------------------------------------------
+    private void setupNavigator() {
+        new Navigator(this, this, viewProvider, getNavigatorPaths());
+    }
+
+    private List<Route> getNavigatorPaths() {
+        return Arrays.asList(Route.values());
     }
 
 }

--- a/src/main/java/demo/app/ui/home/HomeView.java
+++ b/src/main/java/demo/app/ui/home/HomeView.java
@@ -1,0 +1,15 @@
+package demo.app.ui.home;
+
+import com.vaadin.ui.Label;
+
+import demo.lib.ui.NavigableView;
+
+public class HomeView extends NavigableView {
+
+    private static final long serialVersionUID = 5999378752344921622L;
+
+    public HomeView() {
+        this.addComponent(new Label(i18n("HOME_VIEW")));
+    }
+
+}

--- a/src/main/java/demo/lib/navigator/Navigator.java
+++ b/src/main/java/demo/lib/navigator/Navigator.java
@@ -1,0 +1,38 @@
+package demo.lib.navigator;
+
+import java.util.List;
+
+import com.vaadin.spring.navigator.SpringViewProvider;
+import com.vaadin.ui.SingleComponentContainer;
+import com.vaadin.ui.UI;
+
+public class Navigator extends com.vaadin.navigator.Navigator {
+
+    private static final long serialVersionUID = 701965341367782734L;
+
+    // Constructor
+    // ------------------------------------------------------------------------
+    /**
+     * Creates a new Navigator instance.
+     *
+     * @param ui
+     *            the application UI which will be managed by this Navigator
+     * @param container
+     *            the Vaadin container where the views will be shown
+     * @param viewProvider
+     *            the ViewProvider which will handle the views
+     * @param paths
+     *            the list of "paths-views" pairs to be attached to this
+     *            Navigator
+     */
+    public Navigator(UI ui, SingleComponentContainer container, SpringViewProvider viewProvider, List<? extends NavigatorPath> paths) {
+        super(ui, container);
+
+        this.addProvider(viewProvider);
+
+        for (NavigatorPath path : paths) {
+            this.addView(path.getPath(), path.getViewClass());
+        }
+    }
+
+}

--- a/src/main/java/demo/lib/navigator/NavigatorPath.java
+++ b/src/main/java/demo/lib/navigator/NavigatorPath.java
@@ -1,0 +1,22 @@
+package demo.lib.navigator;
+
+import demo.lib.ui.NavigableView;
+
+public interface NavigatorPath {
+
+    /**
+     * Returns the URL string for the given navigation path
+     *
+     * @return the URL path
+     */
+    public String getPath();
+
+    /**
+     * Returns the Vaadin view to be shown when navigating to this navigation
+     * path
+     *
+     * @return the view to be shown
+     */
+    public Class<? extends NavigableView> getViewClass();
+
+}

--- a/src/main/java/demo/lib/ui/BaseView.java
+++ b/src/main/java/demo/lib/ui/BaseView.java
@@ -1,0 +1,22 @@
+package demo.lib.ui;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.vaadin.ui.VerticalLayout;
+
+import demo.lib.utils.i18n;
+
+public class BaseView extends VerticalLayout {
+
+    private static final long serialVersionUID = -6926863820248274083L;
+
+    @Autowired
+    private i18n i18n;
+
+    // Public API
+    // ------------------------------------------------------------------------
+    public String i18n(String key) {
+        return i18n.get(key);
+    }
+
+}

--- a/src/main/java/demo/lib/ui/NavigableView.java
+++ b/src/main/java/demo/lib/ui/NavigableView.java
@@ -1,0 +1,17 @@
+package demo.lib.ui;
+
+import com.vaadin.navigator.View;
+import com.vaadin.navigator.ViewChangeListener.ViewChangeEvent;
+
+public abstract class NavigableView extends BaseView implements View {
+
+    private static final long serialVersionUID = -6926863820248274083L;
+
+    // Overrides
+    // ------------------------------------------------------------------------
+    @Override
+    public void enter(ViewChangeEvent event) {
+        // Not implemented
+    }
+
+}

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -1,2 +1,0 @@
-SAMPLE_KEY=Sample key (Default)
-OTHER_KEY=Lorem ipsum

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -1,1 +1,1 @@
-SAMPLE_KEY=Sample key (English)
+HOME_VIEW=Home page

--- a/src/main/resources/i18n/messages_es.properties
+++ b/src/main/resources/i18n/messages_es.properties
@@ -1,1 +1,1 @@
-SAMPLE_KEY=Clave de ejemplo (ES)
+HOME_VIEW=Página principal


### PR DESCRIPTION
Add the navigation system to the project. Described in `README.md` file:

> To navigate between views using a "traditional" URL state management, the project uses a navigation system which follows some rules:
> - All views which can be accessed through a URL must be defined in the `Route` enum (found in `src/main/java/demo/app/navigation/Route.java`. Each one of them defines a `path` (a URL path) and a `viewClass` (the view to be shown when navigating to the path)
> - The view with an empty `path` will be the default view
> - To navigate to other navigable views, use the `navigateTo()` method of the `Navigator` instance (found in `AppUI.getCurrentApp().getNavigator()`)
> - Views in the navigation system must extend `NavigableView`. To create non-navigable views, use `BaseView` (both found in `src/main/demo/lib/ui/`).
